### PR TITLE
Use soft_wrap=True to print long strings properly

### DIFF
--- a/src/air_convert/cli.py
+++ b/src/air_convert/cli.py
@@ -20,7 +20,7 @@ def main(target: Path, output: Path | None = None):
     html = target.read_text()
     result = html_to_airtags(html)
     if output is None:
-        console.print(result)
+        console.print(result, soft_wrap=True)
     else:
         output.write_text(result)
         console.print(f"Air Tags saved to {output}")


### PR DESCRIPTION
Adds `soft_wrap=True` to rich console printing so that newline characters aren't added to long lines of text, causing issues when the text becomes an invalid Python multiline string.

Closes #8 